### PR TITLE
Adapt module path in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/chrisohaver/kubenodes
+module github.com/infobloxopen/kubenodes
 
 go 1.17
 


### PR DESCRIPTION
Due to the move from https://github.com/chrisohaver/kubenodes to https://github.com/infobloxopen/kubenodes module path in `go.mod` needs to change accordingly.

Otherwise, building CoreDNS with the plugin will fail with:

```
go generate coredns.go
go get
go get: github.com/infobloxopen/kubenodes@v0.0.0-20211217163844-0ab51800474b: parsing go.mod:
        module declares its path as: github.com/chrisohaver/kubenodes
                but was required as: github.com/infobloxopen/kubenodes
make: *** [gen] Error 1
```